### PR TITLE
fix: add dummy inits in bruno env

### DIFF
--- a/deployment/bruno/quality-demo/environments/local-deployment.bru
+++ b/deployment/bruno/quality-demo/environments/local-deployment.bru
@@ -1,10 +1,10 @@
 vars {
-  CUSTOMER_EDC_API_KEY:
-  CUSTOMER_PURIS_BACKEND_API_KEY:
-  CUSTOMER_MANAGE_CLIENT_SECRET:
-  SUPPLIER_EDC_API_KEY:
-  SUPPLIER_PURIS_BACKEND_API_KEY:
-  SUPPLIER_MANAGE_CLIENT_SECRET:
+  CUSTOMER_EDC_API_KEY: (gets_initialized_by_script)
+  CUSTOMER_PURIS_BACKEND_API_KEY: (gets_initialized_by_script)
+  CUSTOMER_MANAGE_CLIENT_SECRET: (gets_initialized_by_script)
+  SUPPLIER_EDC_API_KEY: (gets_initialized_by_script)
+  SUPPLIER_PURIS_BACKEND_API_KEY: (gets_initialized_by_script)
+  SUPPLIER_MANAGE_CLIENT_SECRET: (gets_initialized_by_script)
   CUSTOMER_PURIS_BACKEND: http://localhost:8081
   CUSTOMER_EDC: http://localhost:8181
   PROTOCOL_PATH: api/v1/dsp


### PR DESCRIPTION
- currently, the code in lines 187-192 of the generate-keys.sh script were not properly working, when the value-entries in the bruno env file were totally empty
- inserted some placeholder data into the env file in order to make the script worker